### PR TITLE
fix: avoid fatal error when CA list lags behind updates

### DIFF
--- a/src/main/java/io/septem150/xeric/ProjectXericManager.java
+++ b/src/main/java/io/septem150/xeric/ProjectXericManager.java
@@ -540,6 +540,11 @@ public class ProjectXericManager {
       int caStructId = iterator.next();
       StructComposition struct = client.getStructComposition(caStructId);
       int caTaskId = struct.getIntValue(CA_STRUCT_ID_PARAM_ID);
+
+      // We may lag behind updating this array for new CAs - avoid fatal error by skipping.
+      if (caTaskId/32 >= SCRIPT_4834_VARP_IDS.length)
+        continue;
+
       boolean unlocked =
           (client.getVarpValue(SCRIPT_4834_VARP_IDS[caTaskId / 32]) & (1 << (caTaskId % 32))) != 0;
       if (unlocked) {


### PR DESCRIPTION
`CombatAchievement.SCRIPT_4834_VARP_IDS` contains a list of known varps for checking CAs. We check all CAs against this list when counting the number of CAs the user has competed - new CAs have been added, so accesses to `SCRIPT_4834_VARP_IDS` can go out of bounds.

Adds simple to check to prevent this - we should also update the array, but I'm unsure how these values were determined to begin with